### PR TITLE
Isolate cryptotron sub-app from global :focus-visible styles

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -37,8 +37,11 @@ h1, h2, h3, h4, .mystical-text {
   font-weight: normal;
 }
 
-:focus-visible {
+/* Only apply focus styles to elements NOT inside the cryptotron-container */
+:focus-visible:not(.cryptotron-container *):not(.cryptotron-container) {
   outline: 2px solid #64ffda;
   outline-offset: 4px;
   box-shadow: 0 0 15px rgba(100, 255, 218, 0.5);
 }
+
+


### PR DESCRIPTION
- Scoped global focus styles to exclude .cryptotron-container and its descendants
- Prevents unwanted shadow effects on the CryptoTron sub-app while maintaining accessibility in the main app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted focus styling behavior for interactive elements, excluding certain UI components from standard focus treatment during keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->